### PR TITLE
Fix Update Version step in push GHA

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -112,6 +112,7 @@ jobs:
     if: needs.tag-github.outputs.changed == 'true'
     steps:
       - uses: actions/checkout@v4
+        token: ${{ secrets.GH_ONF_BOT_PAT }}
 
       - name: Increment version
         run: |


### PR DESCRIPTION
We're seeing a 403 when attempting to push with the create-pull- request action. I believe this is being caused by the fact that the checkout is being done using the default action token, but the push is trying to use the onf-bot's PAT. Using the same token for both should fix the error.